### PR TITLE
Redis update to v7.0.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG REDIS_VERSION=7.0.11
-ARG BUILDER_RUST_VERSION=1.69.0
+ARG REDIS_VERSION=7.0.12
+ARG BUILDER_RUST_VERSION=1.70.0-bookworm
 
 FROM redis:${REDIS_VERSION} AS redis
 FROM rust:${BUILDER_RUST_VERSION} AS moduleBuilder
@@ -11,12 +11,20 @@ RUN mkdir -p ${MODULE_PATH}
 
 COPY --from=redis /usr/local/ /usr/local/
 
+# Python fix for Debian 12 Bookworm
+RUN rm /usr/lib/python3.11/EXTERNALLY-MANAGED
+
 # https://github.com/RediSearch/RediSearch
 ARG MODULE=RediSearch
-ARG VERSION=v2.6.9
+ARG VERSION=v2.6.12
 WORKDIR /modules
 RUN git clone --recursive --depth 1 --branch ${VERSION} https://github.com/${MODULE}/${MODULE}.git
 WORKDIR /modules/${MODULE}
+
+# Fix for Python 3.11 (numpy 1.21.6 and nscipy 1.7.3 requires Python < 3.11), affects module tests only
+RUN ./deps/readies/bin/getpy3
+RUN echo "numpy == 1.25.1\nscipy == 1.9.3" > /modules/RediSearch/tests/pytests/requirements.linux.txt
+
 # BULD
 RUN make setup
 RUN make fetch SHOW=1
@@ -37,7 +45,7 @@ RUN cp /modules/${MODULE}/target/release/librejson.so ${MODULE_PATH}/rejson.so
 
 # https://github.com/RedisTimeSeries/RedisTimeSeries
 ARG MODULE=RedisTimeSeries
-ARG VERSION=v1.8.10
+ARG VERSION=v1.8.11
 WORKDIR /modules
 RUN git clone --recursive --branch ${VERSION} https://github.com/${MODULE}/${MODULE}.git
 WORKDIR /modules/${MODULE}


### PR DESCRIPTION
- Update Redis to v7.0.12
- Update Redis modules
- Update buster to bookworm